### PR TITLE
feat: add validation to prevent linking existing Calendly accounts to different mentors

### DIFF
--- a/src/modules/calendly/repository/calendly.repository.ts
+++ b/src/modules/calendly/repository/calendly.repository.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../../prisma/service/prisma.service';
 import {
   CreateCalendlyInfoDto,
@@ -63,6 +63,23 @@ export class CalendlyRepository {
     mentorId: string,
     updateCalendlyInfoDto: UpdateCalendlyInfoDto,
   ) {
+    if (updateCalendlyInfoDto.calendlyUserUuid) {
+      const existingCalendly = await this.prisma.calendlyInfo.findFirst({
+        where: {
+          calendlyUserUuid: updateCalendlyInfoDto.calendlyUserUuid,
+          mentorId: {
+            not: mentorId,
+          },
+        },
+      });
+
+      if (existingCalendly) {
+        throw new BadRequestException(
+          'Não foi possível vincular esta agenda. Verifique se ela já está em uso  por outro perfil de mentor e tente novamente.',
+        );
+      }
+    }
+
     return this.prisma.calendlyInfo.upsert({
       where: { mentorId },
       update: updateCalendlyInfoDto,


### PR DESCRIPTION
essa PR corrige um bug de que  um perfil de mentor vincule mais de uma agenda 

link do issue -> https://github.com/SouJunior/products/issues/523

como corrigi esse erro
* fiz uma validação na classe  calendly repository , fiz essa validação com findFirst , seguindo o padrão do projeto
* essa validação retorna uma bad requestion quando o usuário tenta   vincular mais de uma agenda em um mesmo perfil  