### PR TITLE
Feature/1356 disparo email criar nova agenda

### DIFF
--- a/src/modules/calendly/calendly.controller.ts
+++ b/src/modules/calendly/calendly.controller.ts
@@ -32,7 +32,6 @@ import {
   CreateCalendlyInviteeDto,
   GetCalendlyAvailableTimesDto,
 } from './dto/calendly-scheduling.dto';
-import { MailService } from '../mails/mail.service';
 
 @Controller('calendly')
 export class CalendlyController {
@@ -45,7 +44,6 @@ export class CalendlyController {
     private getCalendlyMentorInfoService: GetCalendlyMentorInfoService,
     private getAllCalendlyMentorInfosService: GetAllCalendlyMentorInfosService,
     private calendlySchedulingService: CalendlySchedulingService,
-    private readonly mailService: MailService,
   ) {}
 
   @Get('')
@@ -141,9 +139,8 @@ export class CalendlyController {
     const result = await this.createCalendlyInfoService.execute(
       data,
       mentor.id,
+      mentor.email,
     );
-
-    void this.mailService.calendlyUpdated(mentor.email).catch(() => {});
 
     return result;
   }
@@ -157,9 +154,8 @@ export class CalendlyController {
     const result = await this.updateCalendlyInfoService.execute(
       mentor.id,
       data,
+      mentor.email,
     );
-
-    void this.mailService.calendlyUpdated(mentor.email).catch(() => {});
 
     return result;
   }

--- a/src/modules/calendly/calendly.controller.ts
+++ b/src/modules/calendly/calendly.controller.ts
@@ -32,6 +32,7 @@ import {
   CreateCalendlyInviteeDto,
   GetCalendlyAvailableTimesDto,
 } from './dto/calendly-scheduling.dto';
+import { MailService } from '../mails/mail.service';
 
 @Controller('calendly')
 export class CalendlyController {
@@ -44,6 +45,7 @@ export class CalendlyController {
     private getCalendlyMentorInfoService: GetCalendlyMentorInfoService,
     private getAllCalendlyMentorInfosService: GetAllCalendlyMentorInfosService,
     private calendlySchedulingService: CalendlySchedulingService,
+    private readonly mailService: MailService,
   ) {}
 
   @Get('')
@@ -136,7 +138,14 @@ export class CalendlyController {
     @Body() data: CreateCalendlyInfoDto,
     @LoggedEntity() mentor: MentorEntity,
   ) {
-    return await this.createCalendlyInfoService.execute(data, mentor.id);
+    const result = await this.createCalendlyInfoService.execute(
+      data,
+      mentor.id,
+    );
+
+    void this.mailService.calendlyUpdated(mentor.email).catch(() => {});
+
+    return result;
   }
 
   @Put(':id')
@@ -145,6 +154,13 @@ export class CalendlyController {
     @Body() data: UpdateCalendlyInfoDto,
     @LoggedEntity() mentor: MentorEntity,
   ) {
-    return await this.updateCalendlyInfoService.execute(mentor.id, data);
+    const result = await this.updateCalendlyInfoService.execute(
+      mentor.id,
+      data,
+    );
+
+    void this.mailService.calendlyUpdated(mentor.email).catch(() => {});
+
+    return result;
   }
 }

--- a/src/modules/calendly/calendly.module.ts
+++ b/src/modules/calendly/calendly.module.ts
@@ -18,6 +18,7 @@ import { CalendlySchedulingService } from './services/calendly-scheduling.servic
 import { UserRepository } from '../user/user.repository';
 import { MentorshipFeedbackRepository } from '../mentorship-feedback/repository/mentorship-feedback.repository';
 import { SyncMentorshipHistoryService } from '../mentorship-feedback/services/sync-mentorship-history.service';
+import { GetMentorByIdService } from '../mentors/services/getMentorById.service';
 
 @Module({
   imports: [PassportModule.register({ defaultStrategy: 'jwt' })],
@@ -31,6 +32,7 @@ import { SyncMentorshipHistoryService } from '../mentorship-feedback/services/sy
     UpdateCalendlyInfoService,
     GetCalendlyMentorInfoService,
     GetAllCalendlyMentorInfosService,
+    GetMentorByIdService,
     CalendlySchedulingService,
     MentorshipFeedbackRepository,
     SyncMentorshipHistoryService,

--- a/src/modules/calendly/services/calendly-callback.service.ts
+++ b/src/modules/calendly/services/calendly-callback.service.ts
@@ -8,6 +8,7 @@ import { IHttpAdapter } from '../../../lib/adapter/httpAdapterInterface';
 import { GetMentorByIdService } from 'src/modules/mentors/services/getMentorById.service';
 import { UpdateCalendlyInfoDto } from '../dto/calendly-info-dto';
 import { UpdateCalendlyInfoService } from './update-calendly-info.service';
+import { CustomNotFoundException } from 'src/shared/exceptions/notFound.exception';
 
 @Injectable()
 export class OAuthCallbackService {
@@ -43,22 +44,24 @@ export class OAuthCallbackService {
 
       const mentorResult = await this.getMentorByIdService.execute(mentorId);
 
-      if (mentorResult.status === 200) {
-        const mentor = mentorResult.data;
-
-        const calendlyInfoDto: UpdateCalendlyInfoDto = {
-          calendlyAccessToken: accessToken,
-          calendlyRefreshToken: refreshToken,
-          accessTokenExpiration: expirationTime,
-        };
-
-        await this.updateCalendlyInfo.execute(
-          mentor.id,
-          calendlyInfoDto,
-          mentor.email,
-          false
-        );
+      if (mentorResult.status !== 200 || !mentorResult.data) {
+        throw new CustomNotFoundException('Mentor not found');
       }
+
+      const mentor = mentorResult.data;
+
+      const calendlyInfoDto: UpdateCalendlyInfoDto = {
+        calendlyAccessToken: accessToken,
+        calendlyRefreshToken: refreshToken,
+        accessTokenExpiration: expirationTime,
+      };
+
+      await this.updateCalendlyInfo.execute(
+        mentor.id,
+        calendlyInfoDto,
+        mentor.email,
+        false,
+      );
 
       return { message: 'OAuth successful' };
     } catch (error) {

--- a/src/modules/calendly/services/calendly-callback.service.ts
+++ b/src/modules/calendly/services/calendly-callback.service.ts
@@ -3,13 +3,17 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common';
-import { CalendlyRepository } from '../repository/calendly.repository';
+
 import { IHttpAdapter } from '../../../lib/adapter/httpAdapterInterface';
+import { GetMentorByIdService } from 'src/modules/mentors/services/getMentorById.service';
+import { UpdateCalendlyInfoDto } from '../dto/calendly-info-dto';
+import { UpdateCalendlyInfoService } from './update-calendly-info.service';
 
 @Injectable()
 export class OAuthCallbackService {
   constructor(
-    private readonly calendlyRepository: CalendlyRepository,
+    private readonly updateCalendlyInfo: UpdateCalendlyInfoService,
+    private readonly getMentorByIdService: GetMentorByIdService,
     @Inject('IHttpAdapter') private readonly httpAdapter: IHttpAdapter,
   ) {}
 
@@ -37,11 +41,24 @@ export class OAuthCallbackService {
       const expiresIn = tokenResponse.expires_in;
       const expirationTime = new Date(Date.now() + expiresIn * 1000);
 
-      await this.calendlyRepository.updateCalendlyInfo(mentorId, {
-        calendlyAccessToken: accessToken,
-        calendlyRefreshToken: refreshToken,
-        accessTokenExpiration: expirationTime,
-      });
+      const mentorResult = await this.getMentorByIdService.execute(mentorId);
+
+      if (mentorResult.status === 200) {
+        const mentor = mentorResult.data;
+
+        const calendlyInfoDto: UpdateCalendlyInfoDto = {
+          calendlyAccessToken: accessToken,
+          calendlyRefreshToken: refreshToken,
+          accessTokenExpiration: expirationTime,
+        };
+
+        await this.updateCalendlyInfo.execute(
+          mentor.id,
+          calendlyInfoDto,
+          mentor.email,
+          false
+        );
+      }
 
       return { message: 'OAuth successful' };
     } catch (error) {

--- a/src/modules/calendly/services/calendly-callback.service.ts
+++ b/src/modules/calendly/services/calendly-callback.service.ts
@@ -1,4 +1,5 @@
 import {
+  HttpException,
   Inject,
   Injectable,
   InternalServerErrorException,
@@ -69,6 +70,11 @@ export class OAuthCallbackService {
         'Error during OAuth process:',
         error.response?.data || error.message,
       );
+
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
       throw new InternalServerErrorException(
         'OAuth process failed. Please try again.',
       );

--- a/src/modules/calendly/services/create-calendly-info.service.ts
+++ b/src/modules/calendly/services/create-calendly-info.service.ts
@@ -1,17 +1,30 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { CalendlyRepository } from '../repository/calendly.repository';
 import { CreateCalendlyInfoDto } from '../dto/calendly-info-dto';
+import { MailService } from 'src/modules/mails/mail.service';
 
 @Injectable()
 export class CreateCalendlyInfoService {
-  constructor(private readonly calendlyRepository: CalendlyRepository) {}
+  constructor(
+    private readonly calendlyRepository: CalendlyRepository,
+    private readonly mailService: MailService,
+  ) {}
 
-  async execute(data: CreateCalendlyInfoDto, mentorId: string) {
+  async execute(
+    data: CreateCalendlyInfoDto,
+    mentorId: string,
+    mentorEmail?: string,
+  ) {
     try {
       const calendlyInfo = await this.calendlyRepository.createCalendlyInfo(
         data,
         mentorId,
       );
+
+      if (mentorEmail) {
+        void this.mailService.calendlyUpdated(mentorEmail).catch(() => {});
+      }
+
       return calendlyInfo;
     } catch (error) {
       console.error('Error creating Calendly info:', error.message);

--- a/src/modules/calendly/services/update-calendly-info.service.ts
+++ b/src/modules/calendly/services/update-calendly-info.service.ts
@@ -2,22 +2,35 @@ import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { CalendlyRepository } from '../repository/calendly.repository';
 import { UpdateCalendlyInfoDto } from '../dto/calendly-info-dto';
 import { MentorRepository } from '../../../modules/mentors/repository/mentor.repository';
+import { MailService } from 'src/modules/mails/mail.service';
 
 @Injectable()
 export class UpdateCalendlyInfoService {
   constructor(
     private readonly calendlyRepository: CalendlyRepository,
     private readonly mentorRepository: MentorRepository,
+    private readonly mailService: MailService,
   ) {}
 
-  async execute(mentorId: string, data: UpdateCalendlyInfoDto) {
+  async execute(
+    mentorId: string,
+    data: UpdateCalendlyInfoDto,
+    mentorEmail?: string,
+    shouldRegisterComplete = true,
+  ) {
     try {
-      await this.mentorRepository.registerCompleteToggle(mentorId);
+      if (shouldRegisterComplete) {
+        await this.mentorRepository.registerCompleteToggle(mentorId);
+      }
 
       const calendlyInfo = await this.calendlyRepository.updateCalendlyInfo(
         mentorId,
         data,
       );
+
+      if (mentorEmail) {
+        void this.mailService.calendlyUpdated(mentorEmail).catch(() => {});
+      }
 
       return calendlyInfo;
     } catch (error) {

--- a/src/modules/mails/__tests__/mail.service.spec.ts
+++ b/src/modules/mails/__tests__/mail.service.spec.ts
@@ -4,16 +4,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MailService } from '../mail.service';
 
 describe('MailService.calendlyUpdated', () => {
+  const frontendUrlMock = 'https://frontend.test';
+  const originalFrontendUrl = process.env.FRONTEND_URL;
+
   let service: MailService;
   let mailerService: {
     sendMail: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
-    expect(
-      process.env.FRONTEND_URL?.trim(),
-      'FRONTEND_URL must be defined and non-empty in the environment',
-    ).toBeTruthy();
+    process.env.FRONTEND_URL = frontendUrlMock;
 
     mailerService = {
       sendMail: vi.fn().mockResolvedValue(undefined),
@@ -23,6 +23,7 @@ describe('MailService.calendlyUpdated', () => {
   });
 
   afterEach(() => {
+    process.env.FRONTEND_URL = originalFrontendUrl;
     vi.restoreAllMocks();
   });
 
@@ -35,7 +36,7 @@ describe('MailService.calendlyUpdated', () => {
         to: 'mentor@email.com',
         template: './calendlyUpdated',
         context: {
-          urlHome: `${process.env.FRONTEND_URL}/home`,
+          urlHome: `${frontendUrlMock}/home`,
         },
       }),
     );

--- a/src/modules/mails/__tests__/mail.service.spec.ts
+++ b/src/modules/mails/__tests__/mail.service.spec.ts
@@ -1,0 +1,58 @@
+import 'dotenv/config';
+import { MailerService } from '@nestjs-modules/mailer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MailService } from '../mail.service';
+
+describe('MailService.calendlyUpdated', () => {
+  let service: MailService;
+  let mailerService: {
+    sendMail: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    expect(
+      process.env.FRONTEND_URL?.trim(),
+      'FRONTEND_URL must be defined and non-empty in the environment',
+    ).toBeTruthy();
+
+    mailerService = {
+      sendMail: vi.fn().mockResolvedValue(undefined),
+    };
+
+    service = new MailService(mailerService as unknown as MailerService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should send the email with the correct template and context', async () => {
+    await service.calendlyUpdated('mentor@email.com');
+
+    expect(mailerService.sendMail).toHaveBeenCalledOnce();
+    expect(mailerService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'mentor@email.com',
+        template: './calendlyUpdated',
+        context: {
+          urlHome: `${process.env.FRONTEND_URL}/home`,
+        },
+      }),
+    );
+  });
+
+  it('should log errors without propagating them', async () => {
+    const error = new Error('Falha ao enviar e-mail');
+    const consoleSpy = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+
+    mailerService.sendMail.mockRejectedValue(error);
+
+    await expect(
+      service.calendlyUpdated('mentor@email.com'),
+    ).resolves.toBeUndefined();
+
+    expect(consoleSpy).toHaveBeenCalledWith('Falha ao enviar e-mail');
+  });
+});

--- a/src/modules/mails/mail.service.ts
+++ b/src/modules/mails/mail.service.ts
@@ -299,6 +299,26 @@ export class MailService {
     return;
   }
 
+  async calendlyUpdated(email: string): Promise<void> {
+    try {
+      const { FRONTEND_URL } = process.env;
+      const urlHome = `${FRONTEND_URL}/home`;
+      await this.mailerService
+        .sendMail({
+          to: email,
+          subject:
+            '📆 Sua agenda está atualizada!  Agora você está disponível para novas mentorias 💙',
+          template: './calendlyUpdated',
+          context: {
+            urlHome,
+          },
+        })
+        .catch(handleError);
+    } catch (error) {
+      console.log(error.message);
+    }
+  }
+
   async sendEmail({ subject, template, context, email }: EmailTemplateType) {
     return; // remover depois que for resolvido
     await this.mailerService.sendMail({

--- a/src/modules/mails/templates/calendlyUpdated.hbs
+++ b/src/modules/mails/templates/calendlyUpdated.hbs
@@ -13,14 +13,6 @@
         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 600px; margin: 0 auto; border-collapse: collapse;">
           <tr>
             <td align="center" style="padding: 0 0 16px;">
-              
-              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
-              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
-              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
-              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
-              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
-              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
-              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
               <img
                 src="https://framerusercontent.com/images/Rn0qNyXiCY39Ka4uQ2msxB26rM.svg?width=790&height=150"
                 width="505"
@@ -37,9 +29,9 @@
           <tr>
             <td align="center" style="padding: 0 0 32px;">
               <img
-                src="https://res.cloudinary.com/dja1rct0m/image/upload/v1705506384/souJunior/cnbmrjhheza1bknzt5yg.png"
+                src="https://vagas-dev.s3.amazonaws.com/1783008078799cnbmrjhheza1bknzt5tl.png"
                 width="360"
-                alt="Garota acenando"
+                alt="Garota usando um notebook"
                 style="display: block; width: 100%; max-width: 360px; height: auto; margin: 0 auto; border: 0;"
               />
             </td>

--- a/src/modules/mails/templates/calendlyUpdated.hbs
+++ b/src/modules/mails/templates/calendlyUpdated.hbs
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Link do Calendly atualizado</title>
+</head>
+<body style="width: 100%; margin: 0; padding: 0; background-color: #ffffff; color: #323232; font-family: Arial, Helvetica, sans-serif; -webkit-text-size-adjust: 100%;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; border-collapse: collapse; background-color: #ffffff;">
+    <tr>
+      <td align="center" style="padding: 32px 16px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 600px; margin: 0 auto; border-collapse: collapse;">
+          <tr>
+            <td align="center" style="padding: 0 0 16px;">
+              
+              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
+              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
+              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
+              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
+              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
+              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
+              {{!-- Substituir pelo link da imagem correta quando estiver disponível. --}}
+              <img
+                src="https://framerusercontent.com/images/Rn0qNyXiCY39Ka4uQ2msxB26rM.svg?width=790&height=150"
+                width="505"
+                alt="SouJunior"
+                style="display: block; width: 100%; max-width: 505px; height: auto; margin: 0 auto; border: 0;"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding: 0 0 32px;">
+              <h1 style="margin: 0; font-size: 32px; line-height: 40px; font-weight: 600;">Link atualizado</h1>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding: 0 0 32px;">
+              <img
+                src="https://res.cloudinary.com/dja1rct0m/image/upload/v1705506384/souJunior/cnbmrjhheza1bknzt5yg.png"
+                width="360"
+                alt="Garota acenando"
+                style="display: block; width: 100%; max-width: 360px; height: auto; margin: 0 auto; border: 0;"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding: 0 24px 32px;">
+              <p style="max-width: 420px; margin: 0 auto; font-size: 16px; line-height: 24px;">
+                O link da sua agenda do Calendly foi atualizado no seu perfil da SouJunior para mentores.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding: 0 0 32px;">
+              <a
+                href="{{urlHome}}"
+                target="_blank"
+                style="display: inline-block; padding: 13px 24px; border-radius: 8px; background-color: #003986; color: #ffffff; font-size: 16px; line-height: 18px; font-weight: 600; text-decoration: none;"
+              >Ir para Home</a>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding: 0 24px;">
+              <p style="max-width: 360px; margin: 0 auto; font-size: 14px; line-height: 20px; font-weight: 500;">
+                Caso não tenha sido você quem realizou as alterações, entre em contato com o
+                <a href="https://www.soujunior.tech/ouvidoria" style="color: #003986;">suporte</a>.<br />
+                Por favor, não responda a este e-mail.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Descrição

Implementa o envio de um e-mail ao mentor após a criação ou atualização de sua agenda do Calendly.

## Alterações realizadas

- Adicionado o método `calendlyUpdated` ao `MailService`.
- Criado um novo template de e-mail para confirmação da atualização da agenda.
- Adicionado o disparo do e-mail após:
  - criação da agenda do Calendly;
  - atualização da agenda existente.
- Adicionados testes unitários para os cenários de sucesso e erro no envio.

## Testes

- Verifica o destinatário, template e contexto enviados ao `MailerService`.
- Verifica o tratamento de falhas no envio sem propagação do erro.

## Checklist

- [x] Funcionalidade implementada
- [x] Template de e-mail criado
- [x] Testes unitários adicionados
- [x] Testes executados com sucesso